### PR TITLE
Update wrangler.jsonc.example

### DIFF
--- a/wrangler.jsonc.example
+++ b/wrangler.jsonc.example
@@ -14,6 +14,7 @@
     "alicloud_key": "",
     "baiduyun_uid": "",
     "baiduyun_key": "",
+    "baiduyun_ext": "",
     "115cloud_uid": "",
     "115cloud_key": "",
     "googleui_uid": "",


### PR DESCRIPTION
缺失了baiduyun_ext的变量，放置百度的SecretKey