### PR TITLE
fix(security): avoid pass plaintext sensitive data to the frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,18 @@
 
 - #### 返回内容
 
-如果执行无误，回返回url
+如果执行无误，会返回经Base64编码的JSON数据。
 
-| 参数名称          | 类型  | 必要 | 示例                             | 说明               |
-| ----------------- | ----- | ---- | -------------------------------- | ------------------ |
-| `<url 302重定向>` | `302` | 否   | `/?......`                       | 返回登录链接到前端 |
-| `access_token`    | `str` | 否   | VqKbrWpetI3HnvyvsWquv9BJFL3j4xjc | 返回访问令牌到前端 |
-| `refresh_token`   | `str` | 否   | oMMPXrCCrRwMoqVD321Z03PSoxmsAKjI | 返回刷新令牌到前端 |
-| `client_uid`      | `str` | 否   | b2eaau943b1bx464                 | 用户传入的客户端ID |
-| `client_key`      | `str` | 否   | SHcAplYIY679BEVF9FveGKtLuSI6MikU | 用户传入的应用密钥 |
-| `driver_txt`      | `str` | 否   | onedrive                         | 用户传入的驱动类型 |
+| 参数名称          | 类型  | 必要 | 示例                             | 说明                         |
+| ----------------- | ----- | ---- |----------------------------------| ---------------------------- |
+| `<url 302重定向>` | `302` | 否   | `/#eyJhY2Nlc3Nf......`           | 返回编码的数据到前端         |
+| `access_token`    | `str` | 否   | VqKbrWpetI3HnvyvsWquv9BJFL3j4xjc | 返回访问令牌到前端           |
+| `refresh_token`   | `str` | 否   | oMMPXrCCrRwMoqVD321Z03PSoxmsAKjI | 返回刷新令牌到前端           |
+| `server_use`      | `str` | 否   | true                             | 是否使用 OpenList 提供的参数 |
+| `client_uid`      | `str` | 否   | b2eaau943b1bx464                 | 用户传入的客户端ID           |
+| `client_key`      | `str` | 否   | SHcAplYIY679BEVF9FveGKtLuSI6MikU | 用户传入的应用密钥           |
+| `driver_txt`      | `str` | 否   | onedrive                         | 用户传入的驱动类型           |
+| `message_err`     | `str` | 否   | Connection reset by peer         | 服务端错误信息               |
 
 ### 刷新令牌
 
@@ -83,7 +85,7 @@
 
 - #### 返回内容
 
-如果执行无误，回返回url
+如果执行无误，会返回url。
 
 | 参数名称        | 类型  | 必要 | 示例            | 说明               |
 | --------------- | ----- | ---- | --------------- | ------------------ |

--- a/public/static/login.js
+++ b/public/static/login.js
@@ -7,7 +7,6 @@ async function getLogin(refresh = false) {
     let driver_txt = document.getElementById("site-select").value;
     let refresh_ui = document.getElementById("refresh-token").value;
     let driver_pre = driver_txt.split("_")[0]
-    console.log(server_use);
     let check_flag = true;
     // 验证秘钥情况 ==================================================
     if (!server_use) {
@@ -109,7 +108,6 @@ async function getLogin(refresh = false) {
                 }).then(async (result) => {
                     if (result.isConfirmed) {
                         const authCode = result.value;
-                        console.log('授权码:', authCode);
                         window.location.href = "/baiduyun/callback" +
                             "?server_oob=true" + "&secret_key=" + secret_key +
                             "&client_key=" + client_key + "&code=" + authCode;
@@ -139,10 +137,14 @@ async function getLogin(refresh = false) {
                 let auth_post = await fetch(post_urls, {method: 'GET'});
                 let auth_data = await auth_post.json();
                 if (auth_post.status === 200) {
-                    window.location.href = `/?access_token=${auth_data.access_token}`
-                        + `&refresh_token=${auth_data.refresh_token}`
-                        + `&client_uid=${client_uid}`
-                        + `&client_key=${client_key}`;
+                    const callbackData = {
+                        access_token: auth_data.access_token,
+                        refresh_token: auth_data.refresh_token,
+                        client_uid: client_uid,
+                        client_key: client_key
+                    };
+                    window.location.hash = "#" + encodeCallbackData(callbackData);
+                    getToken();
                 }
             }
 
@@ -160,4 +162,8 @@ async function getLogin(refresh = false) {
             timer: 1000
         });
     }
+}
+
+function encodeCallbackData(data) {
+    return btoa(JSON.stringify(data))
 }

--- a/public/static/token.js
+++ b/public/static/token.js
@@ -1,23 +1,46 @@
 async function getToken() {
-    const strSearch = window.location.search;
-    const urlParams = new URLSearchParams(strSearch);
-    const server_use = urlParams.get("server_use");
-    const client_uid = urlParams.get("client_uid");
-    const secret_key = urlParams.get("secret_key");
-    const driver_txt = urlParams.get("driver_txt");
-    const client_key = urlParams.get("client_key");
-    const access_token = urlParams.get("access_token");
-    const refresh_token = urlParams.get("refresh_token");
-    const message_err = urlParams.get("message_err");
-    document.getElementById("site-select").value = driver_txt;
-    if (!driver_txt || driver_txt === "")
-        document.getElementById("site-select").value = "onedrive_go";
-    document.getElementById("app-secret").value = client_key;
-    document.getElementById("client-id").value = client_uid;
-    document.getElementById("access-token").value = access_token;
-    document.getElementById("refresh-token").value = refresh_token;
-    if (secret_key)
-        document.getElementById("secret-key").value = secret_key;
+    const hash = window.location.hash.substring(1); // 去掉#号Add commentMore actions
+    let message_err = "";
+    if (hash) {
+        try {
+            const callbackData = JSON.parse(atob(hash));
+            const server_use = callbackData.server_use;
+            const client_uid = callbackData.client_uid;
+            const secret_key = callbackData.secret_key;
+            const driver_txt = callbackData.driver_txt;
+            const client_key = callbackData.client_key;
+            const access_token = callbackData.access_token;
+            const refresh_token = callbackData.refresh_token;
+
+            // 从历史记录清除#号部分，避免隐私信息泄漏
+            // 这只会在正常解析JSON后执行，其他的hash不会被清除
+            // window.history.replaceState(null, null, window.location.pathname + window.location.search);
+            // 在Chrome 136测试发现，通过History API操作，不但不会修改记录反而还会多出一条记录。
+            // Chrome浏览器可以使用location.replace修改记录，Firefox浏览器上此方法无效。
+            // 参见：https://stackoverflow.com/questions/61711130/removing-sensitive-url-data-from-borwser-history
+            window.location.replace('#');
+
+            if (server_use == "true") {
+                document.getElementById("server_use").checked = true;
+            }
+            message_err = callbackData.message_err;
+
+            document.getElementById("site-select").value = driver_txt;
+            if (!driver_txt || driver_txt === "") {
+                document.getElementById("site-select").value = "onedrive_go";
+            }
+            document.getElementById("app-secret").value = client_key;
+            document.getElementById("client-id").value = client_uid;
+            document.getElementById("access-token").value = access_token;
+            document.getElementById("refresh-token").value = refresh_token;
+            if (secret_key) {
+                document.getElementById("secret-key").value = secret_key;
+            }
+        } catch (e) {
+            // hash不是JSON，可能是HTML内的锚点
+        }
+    }
+
     // 获取select元素和输入框元素
     const siteSelect = document.getElementById('site-select');
     const callbackUrlInput = document.getElementById('callback-url');

--- a/public/static/token.js
+++ b/public/static/token.js
@@ -3,7 +3,9 @@ async function getToken() {
     let message_err = "";
     if (hash) {
         try {
-            const callbackData = JSON.parse(atob(hash));
+            const jsonBytes = Uint8Array.from(atob(hash), c => c.charCodeAt(0));
+            const json = new TextDecoder().decode(jsonBytes);
+            const callbackData = JSON.parse(json);
             const server_use = callbackData.server_use;
             const client_uid = callbackData.client_uid;
             const secret_key = callbackData.secret_key;

--- a/src/115ui.ts
+++ b/src/115ui.ts
@@ -3,6 +3,7 @@ import {Context} from "hono";
 import {showErr} from "./error";
 import * as configs from "./shares/configs";
 import * as refresh from "./shares/refresh";
+import {encodeCallbackData} from "./shares/callback-data";
 
 
 const driver_map: string[] = [
@@ -20,7 +21,7 @@ export async function oneLogin(c: Context) {
     if (server_use == "false" && (!driver_txt || !client_uid || !client_key))
         return c.json({text: "参数缺少"}, 500);
     const random_key = getRandomString(64);
-    console.log(server_use);
+
     // 请求参数 ==========================================================================
     const params_all: Record<string, any> = {
         client_id: server_use == "true" ? c.env.cloud115_uid : client_uid,
@@ -42,7 +43,6 @@ export async function oneLogin(c: Context) {
         local.setCookie(c, 'driver_txt', driver_txt);
         local.setCookie(c, 'random_key', random_key);
         local.setCookie(c, 'server_use', server_use);
-        console.log(response);
         return c.json({text: response.url}, 200);
     } catch (error) {
         return c.json({text: error}, 500);
@@ -52,7 +52,7 @@ export async function oneLogin(c: Context) {
 // 令牌申请 ##############################################################################
 export async function oneToken(c: Context) {
     let login_data, client_uid, client_key, random_key, client_url;
-    let server_use, params_all, random_uid, driver_txt;
+    let server_use, params_all: Record<string, any>, random_uid, driver_txt;
     try { // 请求参数 ====================================================================
         login_data = c.req.query('code');
         random_uid = c.req.query('state');
@@ -78,7 +78,12 @@ export async function oneToken(c: Context) {
     } catch (error) {
         return c.redirect(showErr(<string>error, "", ""));
     }
-    // console.log(login_data);
+
+    // 避免key泄漏
+    if (server_use == "true") {
+        client_uid = "";
+        client_key = "";
+    }
 
     // 执行请求 ===========================================================================
     try {
@@ -98,13 +103,15 @@ export async function oneToken(c: Context) {
         local.deleteCookie(c, 'server_use');
         let json: Record<string, any> = await response.json();
         if (json.state == 1) {
-            return c.redirect(
-                `/?access_token=${json.data.access_token}`
-                + `&refresh_token=${json.data.refresh_token}`
-                + `&client_uid=${server_use == "true" ? "" : client_uid}`
-                + `&client_key=${server_use == "true" ? "" : client_key}`
-                + `&driver_txt=${driver_txt}`
-            );
+            const callbackData: CallbackData  = {
+                access_token: json.data.access_token,
+                refresh_token: json.data.refresh_token,
+                client_uid: client_uid,
+                client_key: client_key,
+                driver_txt: driver_txt,
+                server_use: server_use,
+            };
+            return c.redirect("/#" + encodeCallbackData(callbackData));
         }
         return c.redirect(showErr(json.message, client_uid, client_key));
     } catch (error) {

--- a/src/123ui.ts
+++ b/src/123ui.ts
@@ -1,6 +1,5 @@
 import * as local from "hono/cookie";
 import {Context} from "hono";
-import {showErr} from "./error";
 
 
 const driver_map: string[] = [
@@ -14,7 +13,6 @@ export async function oneLogin(c: Context) {
     const client_key: string = <string>c.req.query('client_key');
     const driver_txt: string = <string>c.req.query('driver_txt');
     const server_use: string = <string>c.req.query('server_use');
-    console.log(server_use);
     if (server_use == "false" && (!driver_txt || !client_uid || !client_key))
         return c.json({text: "参数缺少"}, 500);
     // 请求参数 ==========================================================================
@@ -34,7 +32,6 @@ export async function oneLogin(c: Context) {
         });
         const json: Record<string, any> = await response.json();
         local.setCookie(c, 'driver_txt', driver_txt);
-        console.log(json);
         return c.json({text: json.data.accessToken}, 200);
     } catch (error) {
         return c.json({text: error}, 500);

--- a/src/aliui.ts
+++ b/src/aliui.ts
@@ -55,7 +55,6 @@ export async function alyLogin(c: Context) {
         local.setCookie(c, 'driver_txt', driver_txt);
         local.setCookie(c, 'server_use', server_use);
         const data: Record<string, any> = await response.json();
-        console.log(data);
         return c.json({
             "text": data.qrCodeUrl,
             "sid": data.sid
@@ -106,7 +105,6 @@ export async function alyToken(c: Context) {
             return c.json({text: `${error.code}: ${error.message}`,}, 403);
         }
         const data: Record<string, any> = await response.json();
-        console.log(data);
         return c.json(data);
     } catch (error) {
         return c.json({text: error}, 500

--- a/src/aliui2.ts
+++ b/src/aliui2.ts
@@ -303,8 +303,8 @@ class AlipanQRLogin {
     // 获取访问令牌
     async getAccessToken(bizExt: any): Promise<string | null> {
         try {
-            console.log('getAccessToken - bizExt type:', typeof bizExt);
-            console.log('getAccessToken - bizExt:', bizExt);
+            // console.log('getAccessToken - bizExt type:', typeof bizExt);
+            // console.log('getAccessToken - bizExt:', bizExt);
             
             // bizExt 是 Base64 编码的字符串，需要先解码
             let decodedBizExt: any;
@@ -312,7 +312,7 @@ class AlipanQRLogin {
                 try {
                     const decodedString = atob(bizExt);
                     decodedBizExt = JSON.parse(decodedString);
-                    console.log('getAccessToken - decoded bizExt:', JSON.stringify(decodedBizExt, null, 2));
+                    // console.log('getAccessToken - decoded bizExt:', JSON.stringify(decodedBizExt, null, 2));
                 } catch (decodeError) {
                     console.error('解码 bizExt 失败:', decodeError);
                     return null;
@@ -322,16 +322,16 @@ class AlipanQRLogin {
             }
             
             if (!decodedBizExt || !decodedBizExt.pds_login_result) {
-                console.log('getAccessToken - No pds_login_result found in decoded data');
+                // console.log('getAccessToken - No pds_login_result found in decoded data');
                 return null;
             }
 
             const loginResult = decodedBizExt.pds_login_result;
-            console.log('getAccessToken - loginResult:', JSON.stringify(loginResult, null, 2));
+            // console.log('getAccessToken - loginResult:', JSON.stringify(loginResult, null, 2));
             this.access_token = loginResult.accessToken;
             this.refresh_token = loginResult.refreshToken;
-            console.log('getAccessToken - access_token set:', this.access_token ? 'success' : 'failed');
-            console.log('getAccessToken - refresh_token set:', this.refresh_token ? 'success' : 'failed');
+            // console.log('getAccessToken - access_token set:', this.access_token ? 'success' : 'failed');
+            // console.log('getAccessToken - refresh_token set:', this.refresh_token ? 'success' : 'failed');
             return this.access_token;
         } catch (error) {
             console.error('获取访问令牌失败:', error);
@@ -441,7 +441,7 @@ function cleanupExpiredSessions() {
     for (const [sessionId, sessionData] of loginSessions.entries()) {
         if (now - sessionData.lastAccess > SESSION_TIMEOUT) {
             loginSessions.delete(sessionId);
-            console.log(`清理过期会话: ${sessionId}`);
+            // console.log(`清理过期会话: ${sessionId}`);
         }
     }
 }
@@ -459,7 +459,7 @@ function getOrCreateSession(sessionId?: string, clientFingerprint?: string): { s
         // 检查会话是否过期
         if (now - sessionData.lastAccess > SESSION_TIMEOUT) {
             loginSessions.delete(sessionId);
-            console.log(`会话已过期，删除: ${sessionId}`);
+            // console.log(`会话已过期，删除: ${sessionId}`);
         } else {
             // 更新最后访问时间
             sessionData.lastAccess = now;
@@ -477,8 +477,8 @@ function getOrCreateSession(sessionId?: string, clientFingerprint?: string): { s
     };
     
     loginSessions.set(newSessionId, newSessionData);
-    console.log(`创建新会话: ${newSessionId}, 客户端指纹: ${clientFingerprint || 'none'}`);
-    
+    // console.log(`创建新会话: ${newSessionId}, 客户端指纹: ${clientFingerprint || 'none'}`);
+
     return { sessionId: newSessionId, sessionData: newSessionData };
 }
 
@@ -526,7 +526,7 @@ export async function generateQR(c: Context) {
             return c.json({error: '生成二维码失败，可能是网络问题或API变化，请稍后重试'}, 500);
         }
 
-        console.log(`会话 ${sessionId} 生成二维码成功`);
+        // console.log(`会话 ${sessionId} 生成二维码成功`);
 
         return c.json({
             success: true,
@@ -578,7 +578,7 @@ export async function checkLogin(c: Context) {
         // 如果登录成功，获取访问令牌
         if (status === 'CONFIRMED') {
             const accessToken = await alipan.getAccessToken(statusResult.content.bizExt);
-            console.log(`会话 ${sessionId} - 登录确认，token获取: ${accessToken ? '成功' : '失败'}`);
+            // console.log(`会话 ${sessionId} - 登录确认，token获取: ${accessToken ? '成功' : '失败'}`);
             if (accessToken) {
                 return c.json({
                     success: true,
@@ -635,7 +635,7 @@ export async function getUserInfo(c: Context) {
         const alipan = sessionData.instance;
 
         // 检查是否已经登录成功
-        console.log(`会话 ${sessionId} - 登录状态: ${alipan.isLoggedIn()}, token: ${alipan.getToken() ? '存在' : '不存在'}`);
+        // console.log(`会话 ${sessionId} - 登录状态: ${alipan.isLoggedIn()}, token: ${alipan.getToken() ? '存在' : '不存在'}`);
         if (!alipan.isLoggedIn()) {
             return c.json({error: '用户尚未登录成功，请先完成扫码登录'}, 400);
         }
@@ -680,7 +680,7 @@ export async function logout(c: Context) {
 
         // 删除会话
         const deleted = loginSessions.delete(sessionId);
-        console.log(`会话 ${sessionId} 退出登录: ${deleted ? '成功' : '会话不存在'}`);
+        // console.log(`会话 ${sessionId} 退出登录: ${deleted ? '成功' : '会话不存在'}`);
 
         return c.json({
             success: true,

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,9 +1,15 @@
-export function showErr(error: string, client_uid: string, client_key: string) {
-    return `/?message_err=${"授权失败，请检查: <br>" +
-        "1、应用ID和应用机密是否正确<br>" +
-        "2、登录账号是否具有应用权限<br>" +
-        "3、回调地址是否包括上面地址<br>" +
-        "错误信息: <br>" + error}`
-        + `&client_uid=${client_uid}`
-        + `&client_key=${client_key}`;
+import {encodeCallbackData} from "./shares/callback-data";
+
+export function showErr(error?: string, client_uid?: string, client_key?: string) {
+    const message_err = "授权失败，请检查:" + "\n" +
+    "1、应用ID和应用机密是否正确" + "\n" +
+    "2、登录账号是否具有应用权限" + "\n" +
+    "3、回调地址是否包括上面地址" + "\n" +
+    "错误信息: " + error;
+    const callbackData: CallbackData = {
+        message_err: message_err,
+        client_uid: client_uid,
+        client_key: client_key,
+    };
+    return "/#" + encodeCallbackData(callbackData);
 }

--- a/src/shares/callback-data.ts
+++ b/src/shares/callback-data.ts
@@ -1,3 +1,7 @@
 export function encodeCallbackData(data: CallbackData) {
-    return btoa(JSON.stringify(data))
+    const json = JSON.stringify(data);
+    // 编码为UTF-8字节数组
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(json);
+    return btoa(String.fromCharCode(...bytes))
 }

--- a/src/shares/callback-data.ts
+++ b/src/shares/callback-data.ts
@@ -1,0 +1,3 @@
+export function encodeCallbackData(data: CallbackData) {
+    return btoa(JSON.stringify(data))
+}

--- a/src/shares/refresh.ts
+++ b/src/shares/refresh.ts
@@ -25,7 +25,6 @@ export async function genToken(c: Context,
             }
         );
         const result_json: Record<string, any> = await result_data.json();
-        console.log(result_json);
         if (getDynamicValue(result_json, refresh_name, Params.refresh_token))
             return c.json({
                 refresh_token: getDynamicValue(result_json, refresh_name, Params.refresh_token),
@@ -33,7 +32,7 @@ export async function genToken(c: Context,
             }, 200);
         return c.json({text: result_json[error_name]}, 500);
     } catch (error) {
-        console.log(error);
+        console.error("刷新token失败", error);
         return c.json({text: error}, 500);
     }
 }

--- a/src/types/callback-data.ts
+++ b/src/types/callback-data.ts
@@ -1,0 +1,11 @@
+// 前端页面使用的回调数据
+interface CallbackData {
+    access_token?: string;
+    refresh_token?: string;
+    server_use?: string | boolean;
+    client_uid?: string;
+    client_key?: string;
+    secret_key?: string;
+    driver_txt?: string;
+    message_err?: string;
+}


### PR DESCRIPTION
- pass sensitive data with URL hash instead of URL query
- encode sensitive data by JSON then encode to base64
- remove debug logs
- remove sensitive data from browser history, tested in Chrome (not work in Firefox)
- avoid return api keys to the frontend when server_use is "true" and error occurred in api request