### PR TITLE
Display fix

### DIFF
--- a/public/static/login.js
+++ b/public/static/login.js
@@ -140,7 +140,7 @@ async function getLogin(refresh = false) {
                 let auth_data = await auth_post.json();
                 if (auth_post.status === 200) {
                     window.location.href = `/?driver_txt=${driver_txt}`
-                        + `access_token=${auth_data.access_token}`
+                        + `&access_token=${auth_data.access_token}`
                         + `&refresh_token=${auth_data.refresh_token}`
                         + `&client_uid=${client_uid}`
                         + `&client_key=${client_key}`;

--- a/public/static/login.js
+++ b/public/static/login.js
@@ -139,7 +139,8 @@ async function getLogin(refresh = false) {
                 let auth_post = await fetch(post_urls, {method: 'GET'});
                 let auth_data = await auth_post.json();
                 if (auth_post.status === 200) {
-                    window.location.href = `/?access_token=${auth_data.access_token}`
+                    window.location.href = `/?driver_txt=${driver_txt}`
+                        + `access_token=${auth_data.access_token}`
                         + `&refresh_token=${auth_data.refresh_token}`
                         + `&client_uid=${client_uid}`
                         + `&client_key=${client_key}`;

--- a/public/static/token.js
+++ b/public/static/token.js
@@ -67,11 +67,15 @@ async function getToken() {
         }
         if (siteSelect.value.split("_")[0] === "onedrive") {
             document.getElementById('sharepoint-url-view').hidden = false;
-            document.getElementById('sharepoint-btn-view').hidden = false;
+            const sharepointBtn = document.getElementById('sharepoint-btn-view');
+            sharepointBtn.classList.add('d-grid');
+            sharepointBtn.hidden = false;
             document.getElementById('sharepoint-uid-view').hidden = false;
         } else {
             document.getElementById('sharepoint-url-view').hidden = true;
-            document.getElementById('sharepoint-btn-view').hidden = true;
+            const sharepointBtn = document.getElementById('sharepoint-btn-view');
+            sharepointBtn.hidden = true;
+            sharepointBtn.classList.remove('d-grid');
             document.getElementById('sharepoint-uid-view').hidden = true;
         }
         if (siteSelect.value.split("_")[0] === "baiduyun") {


### PR DESCRIPTION
- Removed `d-grid` class of sharepoint-btn-view when driver is not OneDrive
- Added `driver_txt` parameter for Alidrive callback

**Follow-up** (Recommendation):
Update OAuth2 application callback settings of OneDrive, 115, Google, Yandex, Baidu to include `driver_txt` parameter